### PR TITLE
Added Windows specific codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor/
 
 .DS_Store
 main
+main.exe

--- a/how_to_contribute.md
+++ b/how_to_contribute.md
@@ -24,7 +24,7 @@ Download the required linting tools of your choice in your code editor for prope
 
 ## Committing your work
 
-All the commits made to the repository should be signed by your Mayadata email ID. For signing-off according to the [DCO standards](http://developercertificate.org/) use -s flag.
+All the commits made to the repository should be signed by your MayaData email ID. For signing-off according to the [DCO standards](http://developercertificate.org/) use -s flag.
 
 **Example:**
 


### PR DESCRIPTION
@IsAmrish I have added new codes but commented out the older mkdir section specifically and only in `main.go`. I would suggest to checkout to the branch to this PR on your local machine and then check if it works on your machine.
Try running code by using
- **`--windows=false`** flag or ignore it and run normally because it is **`false`** by default. Expectation: it should **not** give any errors. If you have some errors then `uncomment` the code and add an `if block` with condition 
```
if *windows{
 ... uncomment code ...
 if _, err := os.Stat(*logsFilePath); os.IsNotExist(err) {
  err := os.Mkdir(*logsFilePath, 0755)
  if err != nil {
   log.Fatal(err)
  }
 }
}
```
![image](https://user-images.githubusercontent.com/46858011/91701317-ba35da00-eb94-11ea-9137-9e5f3d6a6424.png)

- **`--windows=true`**: It may give you some errors on Linux. So check it as well and provide me feedback.

Signed-off-by: Srikant Sahoo <srikant.sahoo@mayadata.io>